### PR TITLE
feat: sort NPY slices numerically to ensure correct mask assembly

### DIFF
--- a/src/new_utils.py
+++ b/src/new_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import nibabel as nib
+import re
 import os
 import cv2
 import matplotlib.pyplot as plt
@@ -149,16 +150,10 @@ class MaskManager:
 
         # Sort files numerically by slice index to preserve correct order
         def extract_slice_index(filename):
-            """Extract slice index from filename like 'slice_5_threshold_0.38.npy'"""
-            parts = filename.split('_')
-            for i, part in enumerate(parts):
-                if part == 'slice' and i + 1 < len(parts):
-                    try:
-                        return int(parts[i + 1])
-                    except ValueError:
-                        continue
-            return 0  # fallback
-        
+            """Extract slice index from filename like 'slice_0005_threshold_0.38.npy'"""
+            match = re.search(r'slice_(\d+)', filename)
+            return int(match.group(1)) if match else 0
+
         npy_files.sort(key=extract_slice_index)
 
         images = []

--- a/src/new_utils.py
+++ b/src/new_utils.py
@@ -133,14 +133,19 @@ class MaskManager:
         return np.count_nonzero(mask)
     
     @staticmethod 
-    
     def create_final_mask(folder_path, original_shape, original_affine):
         """
-        Creates a 3D NIfTI mask from PNG images with dimension matching.
+        Creates a 3D NIfTI mask from processed slice arrays.
 
-        Before stacking PNG slices, identifies the slice dimension in the original volume
-        and ensures proper orientation by comparing spatial dimensions.
+        Args:
+            folder_path: directory containing .npy slice files
+            original_shape: 3D shape of original volume
+            original_affine: affine matrix from original volume
+
+        Returns:
+            str: path to saved mask.nii file
         """
+        
         mask_path = os.path.join(folder_path, 'mask.nii')
 
         # Load and sort NPY files
@@ -197,17 +202,17 @@ class MaskManager:
         nib.save(mask_nii, mask_path)        
         print(f"Mask successfully saved to {mask_path}")
 
-        # removing numpy files after mask creation
-        removed_count=0
-        for npy_file in npy_files:
+        # Clean up temporary .npy files
+        print(f"Cleaning up {len(npy_files)} temporary .npy files...")
+        for f in npy_files:
+            npy_path = os.path.join(folder_path, f)
             try:
-                file_path = os.path.join(folder_path, npy_file)
-                os.remove(file_path)
-                removed_count += 1
-                print(f"Removed: {npy_file}")
+                os.remove(npy_path)
             except Exception as e:
-                print(f"Error removing {npy_file}: {e}")
+                print(f"Warning: Could not remove {f}: {e}")
 
+        print(f"Cleanup complete. Temporary files removed.")
+        
         return mask_path
         
 

--- a/src/new_utils.py
+++ b/src/new_utils.py
@@ -147,6 +147,20 @@ class MaskManager:
         if not npy_files:
             raise FileNotFoundError(f"No NPY files found in {folder_path}")
 
+        # Sort files numerically by slice index to preserve correct order
+        def extract_slice_index(filename):
+            """Extract slice index from filename like 'slice_5_threshold_0.38.npy'"""
+            parts = filename.split('_')
+            for i, part in enumerate(parts):
+                if part == 'slice' and i + 1 < len(parts):
+                    try:
+                        return int(parts[i + 1])
+                    except ValueError:
+                        continue
+            return 0  # fallback
+        
+        npy_files.sort(key=extract_slice_index)
+
         images = []
         for f in npy_files:
             array = np.load(os.path.join(folder_path, f))


### PR DESCRIPTION
This pull request improves the reliability of the `create_final_mask` function by ensuring that NPY files are processed in the correct order. The main change is the addition of a sorting step that orders files numerically based on their slice index extracted from the filename.

Improvements to file processing order:

* Added a helper function `extract_slice_index` to parse the slice index from filenames like `'slice_5_threshold_0.38.npy'` and used it to sort `npy_files` numerically before loading them, ensuring that slices are processed in the correct order.