### PR TITLE
fix: Core orientation fixes

### DIFF
--- a/src/ImageLoader.py
+++ b/src/ImageLoader.py
@@ -3,6 +3,7 @@ import numpy as np
 import pydicom
 import nibabel as nib
 
+
 class BaseImageLoader:
     """Base class for medical image loading operations."""
 
@@ -11,180 +12,249 @@ class BaseImageLoader:
         """
         Determines the central slice index for a 3D volume.
         The slice dimension is assumed to be the smallest dimension.
-        
-        Args:
-            shape: tuple of 3D volume dimensions
-            
-        Returns:
-            int: central slice index along the slice dimension
         """
-        slice_dim = np.argmin(shape)
-        return shape[slice_dim] // 2
+        slice_dim = int(np.argmin(shape))
+        return int(shape[slice_dim] // 2)
+
 
 class NiftiLoader(BaseImageLoader):
     """Specialized loader for NIfTI files - loads in NATIVE orientation."""
-    
+
+    img_type = "nii"
+
     @staticmethod
-    def load_volume(file_path, lazy=False):
+    def load_volume(file_path: str, lazy: bool = False):
         """
         Loads NIfTI volume in its NATIVE orientation.
-        
-        Args:
-            file_path: path to NIfTI file
-            lazy: if True, uses lazy loading
-            
-        Returns:
-            tuple: (data, affine, original_shape)
-                - data: numpy array in NATIVE orientation
-                - affine: 4x4 affine transformation matrix
-                - original_shape: shape of the volume (same as data.shape)
+        Returns: (data, affine, original_shape, img_type)
         """
         img = nib.load(file_path)
         if lazy:
-            data = np.asarray(img.dataobj)  # Lazy loading
+            data = np.asarray(img.dataobj)  # memory-mapped when possible
         else:
             data = img.get_fdata()
-        
-        # NO rearrangement - keep native orientation
+
         original_shape = data.shape
-        return data, img.affine, original_shape
-    
+        return data, img.affine, original_shape, NiftiLoader.img_type
+
     @staticmethod
-    def load_slice(file_path, slice_index=None):
+    def load_slice(file_path: str, slice_index: int | None = None):
         """
-        Loads a specific slice from NIfTI file in NATIVE orientation.
-        
-        Args:
-            file_path (str): Path to NIfTI file
-            slice_index (int, optional): Specific slice index. If None, loads central slice.
-            
-        Returns:
-            tuple: (slice_data, affine, original_shape, slice_index_used)
-                - slice_data: 2D numpy array of the slice in NATIVE orientation
-                - affine: 4x4 affine matrix
-                - original_shape: 3D shape of the full volume
-                - slice_index_used: which slice was actually loaded
+        Loads a specific slice from a NIfTI file in NATIVE orientation.
+        Returns: (slice_data, affine, original_shape, slice_index_used, img_type)
         """
         img = nib.load(file_path)
         original_shape = img.shape
-        
-        # Handle 2D images
+
+        # 2D NIfTI
         if len(original_shape) == 2:
-            slice_data = img.get_fdata()
-            return slice_data, img.affine, original_shape, 0
-        
-        # For 3D volumes, find slice dimension (smallest dimension)
-        slice_dim = np.argmin(original_shape)
-        
-        # Calculate central slice if not specified
+            slice_data = np.asarray(img.dataobj).astype(np.float32)
+            return slice_data, img.affine, original_shape, 0, NiftiLoader.img_type
+
+        # 3D+ : slice dimension assumed smallest
+        slice_dim = int(np.argmin(original_shape))
+
         if slice_index is None:
-            slice_index = original_shape[slice_dim] // 2
-        
-        # Validate slice index
+            slice_index = int(original_shape[slice_dim] // 2)
+
         if slice_index < 0 or slice_index >= original_shape[slice_dim]:
-            raise ValueError(f"Slice index {slice_index} out of range for dimension {slice_dim} with size {original_shape[slice_dim]}")
-        
-        # Load only the required slice using memory mapping (efficient)
-        # Extract slice based on which dimension contains slices
+            raise ValueError(
+                f"Slice index {slice_index} out of range for dimension {slice_dim} "
+                f"with size {original_shape[slice_dim]}"
+            )
+
+        # Efficient slice extraction via dataobj
         if slice_dim == 0:
-            slice_data = np.asarray(img.dataobj[slice_index, :, :])
+            slice_data = np.asarray(img.dataobj[slice_index, :, :], dtype=np.float32)
         elif slice_dim == 1:
-            slice_data = np.asarray(img.dataobj[:, slice_index, :])
-        else:  # slice_dim == 2
-            slice_data = np.asarray(img.dataobj[:, :, slice_index])
-        
-        return slice_data, img.affine, original_shape, slice_index
+            slice_data = np.asarray(img.dataobj[:, slice_index, :], dtype=np.float32)
+        else:
+            slice_data = np.asarray(img.dataobj[:, :, slice_index], dtype=np.float32)
+
+        return slice_data, img.affine, original_shape, slice_index, NiftiLoader.img_type
+
 
 class DicomLoader(BaseImageLoader):
-    """Specialized loader for DICOM series - loads in NATIVE orientation."""
-    
+    """Specialized loader for DICOM series/files - loads in NATIVE orientation."""
+
+    img_type = "DICOM"
+
+    # -----------------------------
+    # Helpers (fast + robust)
+    # -----------------------------
     @staticmethod
-    def load_series(folder_path):
-        """
-        Loads DICOM series in NATIVE orientation (no rearrangement).
-        
-        Args:
-            folder_path: path to folder containing DICOM files
-            
-        Returns:
-            tuple: (volume, affine, original_shape)
-        """
-        # Load DICOM files
-        dicom_files = [os.path.join(folder_path, f) for f in os.listdir(folder_path)
-                      if f.lower().endswith(('.dcm', '.dicom'))]
-        
-        if not dicom_files:
+    def _list_dicom_files(folder_path: str) -> list[str]:
+        # English comment: fast directory scan; accepts .dcm/.dicom
+        files = [
+            os.path.join(folder_path, f)
+            for f in os.listdir(folder_path)
+            if f.lower().endswith((".dcm", ".dicom"))
+        ]
+        if not files:
             raise FileNotFoundError(f"No DICOM files found in {folder_path}")
-        
-        # Sort and load slices
-        dicoms = [pydicom.dcmread(f) for f in dicom_files]
-        dicoms.sort(key=lambda d: int(getattr(d, "InstanceNumber", 0)))
-        
-        # Create 3D volume from slices - native stacking (no rearrangement)
-        volume = np.stack([d.pixel_array for d in dicoms], axis=0)
-        
-        # Return identity matrix as affine for DICOM (could compute real affine from metadata)
+        return files
+
+    @staticmethod
+    def _read_meta(path: str):
+        # English comment: metadata-only read is much faster than loading PixelData
+        return pydicom.dcmread(path, stop_before_pixels=True)
+
+    @staticmethod
+    def _safe_float_list(ds, attr: str, n: int | None = None):
+        v = getattr(ds, attr, None)
+        if v is None:
+            return None
+        try:
+            arr = [float(x) for x in v]
+        except Exception:
+            return None
+        if n is not None and len(arr) != n:
+            return None
+        return arr
+
+    @staticmethod
+    def _sort_series(meta_list: list[tuple[str, object]]) -> list[tuple[str, object]]:
+        """
+        Sort series by ImagePositionPatient projected on slice normal when possible.
+        Fallback: InstanceNumber.
+        """
+        ds0 = meta_list[0][1]
+        iop = DicomLoader._safe_float_list(ds0, "ImageOrientationPatient", 6)
+
+        if iop is not None:
+            row_cos = np.array(iop[:3], dtype=np.float32)
+            col_cos = np.array(iop[3:], dtype=np.float32)
+            slice_cos = np.cross(row_cos, col_cos).astype(np.float32)
+
+            def key(item):
+                ds = item[1]
+                ipp = DicomLoader._safe_float_list(ds, "ImagePositionPatient", 3)
+                if ipp is None:
+                    return float(getattr(ds, "InstanceNumber", 0))
+                return float(np.dot(np.array(ipp, dtype=np.float32), slice_cos))
+
+            return sorted(meta_list, key=key)
+
+        return sorted(meta_list, key=lambda x: int(getattr(x[1], "InstanceNumber", 0)))
+
+    @staticmethod
+    def _compute_affine_series(ds0, ds1=None) -> np.ndarray:
+        """
+        Compute NIfTI affine for a volume stacked as (k, r, c) = (slice, row, col).
+        Uses:
+          - ImageOrientationPatient (6)
+          - ImagePositionPatient (3)
+          - PixelSpacing (2)
+          - slice spacing: from IPP delta projected onto normal (preferred),
+            else SpacingBetweenSlices / SliceThickness.
+        """
+        iop = DicomLoader._safe_float_list(ds0, "ImageOrientationPatient", 6)
+        ipp0 = DicomLoader._safe_float_list(ds0, "ImagePositionPatient", 3)
+        ps = DicomLoader._safe_float_list(ds0, "PixelSpacing", 2)
+
+        if iop is None or ipp0 is None or ps is None:
+            print("WARNING: Missing DICOM orientation tags; using identity affine.")
+            return np.eye(4, dtype=np.float32)
+
+        row_cos = np.array(iop[:3], dtype=np.float32)
+        col_cos = np.array(iop[3:], dtype=np.float32)
+        slice_cos = np.cross(row_cos, col_cos).astype(np.float32)
+
+        row_spacing = float(ps[0])
+        col_spacing = float(ps[1])
+
+        slice_spacing = None
+        if ds1 is not None:
+            ipp1 = DicomLoader._safe_float_list(ds1, "ImagePositionPatient", 3)
+            if ipp1 is not None:
+                delta = np.array(ipp1, dtype=np.float32) - np.array(ipp0, dtype=np.float32)
+                slice_spacing = float(abs(np.dot(delta, slice_cos)))
+
+        if slice_spacing is None or slice_spacing == 0.0:
+            sbs = getattr(ds0, "SpacingBetweenSlices", None)
+            thk = getattr(ds0, "SliceThickness", None)
+            if sbs is not None:
+                slice_spacing = float(sbs)
+            elif thk is not None:
+                slice_spacing = float(thk)
+            else:
+                slice_spacing = 1.0
+
+        aff = np.eye(4, dtype=np.float32)
+        # Indexing is (k, r, c)
+        aff[:3, 0] = slice_cos * slice_spacing
+        aff[:3, 1] = row_cos * row_spacing
+        aff[:3, 2] = col_cos * col_spacing
+        aff[:3, 3] = np.array(ipp0, dtype=np.float32)
+
+        return aff
+
+    # -----------------------------
+    # Public API (DO NOT break)
+    # -----------------------------
+    @staticmethod
+    def load_series(folder_path: str):
+        """
+        Loads DICOM series from a folder.
+        Returns: (volume, affine, original_shape, img_type)
+        volume shape: (num_slices, rows, cols)
+        """
+        dicom_files = DicomLoader._list_dicom_files(folder_path)
+
+        # Metadata-only read (fast) + robust sort
+        meta_list = [(fp, DicomLoader._read_meta(fp)) for fp in dicom_files]
+        meta_list = DicomLoader._sort_series(meta_list)
+
+        ds0 = meta_list[0][1]
+        ds1 = meta_list[1][1] if len(meta_list) > 1 else None
+        affine = DicomLoader._compute_affine_series(ds0, ds1)
+        # Heavy part: load pixels in sorted order
+        slices = []
+        for fp, _ in meta_list:
+            ds = pydicom.dcmread(fp)  # loads PixelData
+            slices.append(ds.pixel_array.astype(np.float32))
+
+        volume = np.stack(slices, axis=0)
         original_shape = volume.shape
-        return volume, np.eye(4), original_shape
-    
+        return volume, affine, original_shape, DicomLoader.img_type
+
     @staticmethod
-    def load_slice(folder_path, slice_index=None):
+    def load_slice(folder_path: str, slice_index: int | None = None):
         """
-        Loads a specific slice from DICOM series.
-        
-        Args:
-            folder_path (str): Path to DICOM directory
-            slice_index (int, optional): Specific slice index. If None, loads central slice.
-            
-        Returns:
-            tuple: (slice_data, affine, original_shape, slice_index_used)
+        Loads a single slice from a DICOM folder series (fast: metadata sort, then 1 pixel read).
+        Returns: (slice_data, affine, original_shape, slice_index_used, img_type)
         """
-        # Load DICOM files metadata first (fast)
-        dicom_files = [os.path.join(folder_path, f) for f in os.listdir(folder_path)
-                      if f.lower().endswith(('.dcm', '.dicom'))]
-        
-        if not dicom_files:
-            raise FileNotFoundError(f"No DICOM files found in {folder_path}")
-        
-        # Sort by InstanceNumber without loading pixel data
-        dicoms = []
-        for file_path in dicom_files:
-            ds = pydicom.dcmread(file_path, stop_before_pixels=True)
-            dicoms.append((file_path, ds))
-        
-        dicoms.sort(key=lambda x: int(getattr(x[1], "InstanceNumber", 0)))
-        
-        # Get total number of slices and image dimensions
-        num_slices = len(dicoms)
-        
-        # Calculate central slice if not specified
+        dicom_files = DicomLoader._list_dicom_files(folder_path)
+
+        meta_list = [(fp, DicomLoader._read_meta(fp)) for fp in dicom_files]
+        meta_list = DicomLoader._sort_series(meta_list)
+
+        num_slices = len(meta_list)
         if slice_index is None:
             slice_index = num_slices // 2
-        elif slice_index >= num_slices:
+
+        if slice_index < 0 or slice_index >= num_slices:
             raise ValueError(f"Slice index {slice_index} out of range. Series has {num_slices} slices.")
-        
-        # Load only the specific slice
-        target_file = dicoms[slice_index][0]
-        ds = pydicom.dcmread(target_file)
+
+        ds0 = meta_list[0][1]
+        ds1 = meta_list[1][1] if len(meta_list) > 1 else None
+        affine = DicomLoader._compute_affine_series(ds0, ds1)
+
+        target_fp = meta_list[slice_index][0]
+        ds = pydicom.dcmread(target_fp)
         slice_data = ds.pixel_array.astype(np.float32)
-        
-        # Get dimensions from first slice to build original_shape
-        rows = ds.Rows
-        cols = ds.Columns
+
+        rows = int(getattr(ds, "Rows", slice_data.shape[0]))
+        cols = int(getattr(ds, "Columns", slice_data.shape[1]))
         original_shape = (num_slices, rows, cols)
-        
-        return slice_data, np.eye(4), original_shape, slice_index
+
+        return slice_data, affine, original_shape, slice_index, DicomLoader.img_type
 
     @staticmethod
-    def load_single_file(file_path):
+    def load_single_file(file_path: str):
         """
-        Loads a single DICOM file (2D slice or multi-frame volume).
-
-        Args:
-            file_path (str): Path to DICOM file (.dcm, .dicom)
-
-        Returns:
-            tuple: (volume, affine, original_shape)
+        Loads a single DICOM file (2D slice or multi-frame).
+        Returns: (volume, affine, original_shape, img_type)
         """
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"DICOM file not found: {file_path}")
@@ -193,38 +263,54 @@ class DicomLoader(BaseImageLoader):
             raise ValueError(f"Not a DICOM file extension: {file_path}")
 
         ds = pydicom.dcmread(file_path)
-
         if "PixelData" not in ds:
             raise ValueError(f"DICOM has no PixelData (not an image): {file_path}")
 
         arr = ds.pixel_array
 
-        # Normalize to 3D volume
+        # Normalize to 3D volume (k,r,c)
         if arr.ndim == 2:
-            volume = arr[np.newaxis, ...].astype(np.float32)  # (1, H, W)
+            volume = arr[np.newaxis, ...].astype(np.float32)
         elif arr.ndim == 3:
-            volume = arr.astype(np.float32)  # (n_frames, H, W)
+            volume = arr.astype(np.float32)
         elif arr.ndim == 4 and arr.shape[-1] == 1:
             volume = arr[..., 0].astype(np.float32)
         else:
             raise ValueError(f"Unsupported DICOM pixel array shape {arr.shape}")
 
         original_shape = volume.shape
-        affine = np.eye(4, dtype=np.float32)
 
-        return volume, affine, original_shape
+        # Best-effort affine for single-file
+        affine = np.eye(4, dtype=np.float32)
+        try:
+            iop = DicomLoader._safe_float_list(ds, "ImageOrientationPatient", 6)
+            ipp = DicomLoader._safe_float_list(ds, "ImagePositionPatient", 3)
+            ps = DicomLoader._safe_float_list(ds, "PixelSpacing", 2)
+            if iop is not None and ipp is not None and ps is not None:
+                row_cos = np.array(iop[:3], dtype=np.float32)
+                col_cos = np.array(iop[3:], dtype=np.float32)
+                slice_cos = np.cross(row_cos, col_cos).astype(np.float32)
+
+                row_spacing = float(ps[0])
+                col_spacing = float(ps[1])
+                slice_spacing = float(getattr(ds, "SliceThickness", 1.0))
+
+                affine = np.eye(4, dtype=np.float32)
+                affine[:3, 0] = slice_cos * slice_spacing
+                affine[:3, 1] = row_cos * row_spacing
+                affine[:3, 2] = col_cos * col_spacing
+                affine[:3, 3] = np.array(ipp, dtype=np.float32)
+        except Exception as e:
+            return e
+
+
+        return volume, affine, original_shape, DicomLoader.img_type
 
     @staticmethod
-    def load_single_slice(file_path, slice_index=None):
+    def load_single_slice(file_path: str, slice_index: int | None = None):
         """
-        Loads a slice from a single DICOM file.
-        
-        Args:
-            file_path: path to DICOM file
-            slice_index: specific slice/frame index
-            
-        Returns:
-            tuple: (slice_data, affine, original_shape, slice_index_used)
+        Loads a slice from a single DICOM file (2D or multi-frame).
+        Returns: (slice_data, affine, original_shape, slice_index_used, img_type)
         """
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"DICOM file not found: {file_path}")
@@ -233,50 +319,62 @@ class DicomLoader(BaseImageLoader):
             raise ValueError(f"Not a DICOM file extension: {file_path}")
 
         ds = pydicom.dcmread(file_path)
-
         if "PixelData" not in ds:
             raise ValueError(f"DICOM has no PixelData: {file_path}")
 
         arr = ds.pixel_array
 
-        # Case A: Single 2D image
+        # Best-effort affine
+        affine = np.eye(4, dtype=np.float32)
+
+        iop = DicomLoader._safe_float_list(ds, "ImageOrientationPatient", 6)
+        ipp = DicomLoader._safe_float_list(ds, "ImagePositionPatient", 3)
+        ps = DicomLoader._safe_float_list(ds, "PixelSpacing", 2)
+        if iop is not None and ipp is not None and ps is not None:
+            row_cos = np.array(iop[:3], dtype=np.float32)
+            col_cos = np.array(iop[3:], dtype=np.float32)
+            slice_cos = np.cross(row_cos, col_cos).astype(np.float32)
+
+            row_spacing = float(ps[0])
+            col_spacing = float(ps[1])
+            slice_spacing = float(getattr(ds, "SliceThickness", 1.0))
+
+            affine = np.eye(4, dtype=np.float32)
+            affine[:3, 0] = slice_cos * slice_spacing
+            affine[:3, 1] = row_cos * row_spacing
+            affine[:3, 2] = col_cos * col_spacing
+            affine[:3, 3] = np.array(ipp, dtype=np.float32)
+
+        # Case A: single 2D
         if arr.ndim == 2:
-            if slice_index is None or slice_index == 0:
-                slice_index_used = 0
-            else:
+            if slice_index not in (None, 0):
                 raise ValueError(f"slice_index={slice_index} invalid for 2D DICOM. Use 0.")
-            
             slice_data = arr.astype(np.float32)
             original_shape = (1, slice_data.shape[0], slice_data.shape[1])
-            return slice_data, np.eye(4, dtype=np.float32), original_shape, slice_index_used
+            return slice_data, affine, original_shape, 0, DicomLoader.img_type
 
-        # Case B: Multi-frame 3D
+        # Case B: multi-frame (k,r,c)
         if arr.ndim == 3:
             n_frames = arr.shape[0]
-            
             if slice_index is None:
-                slice_index_used = n_frames // 2
-            else:
-                if slice_index < 0 or slice_index >= n_frames:
-                    raise ValueError(f"Slice index {slice_index} out of range. File has {n_frames} frames.")
-                slice_index_used = slice_index
-            
-            slice_data = arr[slice_index_used].astype(np.float32)
+                slice_index = n_frames // 2
+            if slice_index < 0 or slice_index >= n_frames:
+                raise ValueError(f"Slice index {slice_index} out of range. File has {n_frames} frames.")
+            slice_data = arr[slice_index].astype(np.float32)
             original_shape = (n_frames, slice_data.shape[0], slice_data.shape[1])
-            return slice_data, np.eye(4, dtype=np.float32), original_shape, slice_index_used
+            return slice_data, affine, original_shape, slice_index, DicomLoader.img_type
 
         # Case C: 4D with single channel
         if arr.ndim == 4 and arr.shape[-1] == 1:
-            arr = arr[..., 0]
-            n_frames = arr.shape[0]
-            slice_index_used = n_frames // 2 if slice_index is None else slice_index
-            
-            if slice_index_used < 0 or slice_index_used >= n_frames:
-                raise ValueError(f"Slice index {slice_index_used} out of range. File has {n_frames} frames.")
-            
-            slice_data = arr[slice_index_used].astype(np.float32)
+            arr3 = arr[..., 0]
+            n_frames = arr3.shape[0]
+            if slice_index is None:
+                slice_index = n_frames // 2
+            if slice_index < 0 or slice_index >= n_frames:
+                raise ValueError(f"Slice index {slice_index} out of range. File has {n_frames} frames.")
+            slice_data = arr3[slice_index].astype(np.float32)
             original_shape = (n_frames, slice_data.shape[0], slice_data.shape[1])
-            return slice_data, np.eye(4, dtype=np.float32), original_shape, slice_index_used
+            return slice_data, affine, original_shape, slice_index, DicomLoader.img_type
 
         raise ValueError(f"Unsupported DICOM pixel array ndim={arr.ndim}")
 
@@ -284,58 +382,41 @@ class DicomLoader(BaseImageLoader):
 class UnifiedImageLoader:
     """
     Unified interface for loading medical images in their NATIVE orientation.
-    
-    Key principle: Load images as-is, apply transformations only for display,
-    and always save in native orientation with correct affine matrix.
     """
 
     @staticmethod
-    def load_image(file_path):
+    def load_image(file_path: str):
         """
         Load complete volume in native orientation.
-        
-        Returns:
-            tuple: (volume, affine, original_shape)
+        Returns: (volume, affine, original_shape, img_type)
         """
         if os.path.isdir(file_path):
             return DicomLoader.load_series(file_path)
-        elif file_path.lower().endswith(('.dcm', '.dicom')):
+        if file_path.lower().endswith((".dcm", ".dicom")):
             return DicomLoader.load_single_file(file_path)
-        elif file_path.lower().endswith(('.nii', '.nii.gz')):
+        if file_path.lower().endswith((".nii", ".nii.gz")):
             return NiftiLoader.load_volume(file_path)
-        else:
-            raise ValueError(f"Unsupported format: {file_path}")
-        
+        raise ValueError(f"Unsupported format: {file_path}")
+
     @staticmethod
-    def load_slice(file_path, slice_index=None):
+    def load_slice(file_path: str, slice_index: int | None = None):
         """
-        Load a specific slice in native orientation.
-        
-        Args:
-            file_path: path to image file or DICOM directory
-            slice_index: specific slice index (None = central slice)
-            
-        Returns:
-            tuple: (slice_data, affine, original_shape, slice_index_used)
+        Load a single slice in native orientation.
+        Returns: (slice_data, affine, original_shape, slice_index_used, img_type)
         """
         if os.path.isdir(file_path):
             return DicomLoader.load_slice(file_path, slice_index)
-        elif file_path.lower().endswith(('.dcm', '.dicom')):
+        if file_path.lower().endswith((".dcm", ".dicom")):
             return DicomLoader.load_single_slice(file_path, slice_index)
-        elif file_path.lower().endswith(('.nii', '.nii.gz')):
+        if file_path.lower().endswith((".nii", ".nii.gz")):
             return NiftiLoader.load_slice(file_path, slice_index)
-        else:
-            raise ValueError(f"Unsupported format: {file_path}")
-    
+        raise ValueError(f"Unsupported format: {file_path}")
+
     @staticmethod
     def get_slice_dimension(original_shape):
         """
         Identifies which dimension contains slices (usually the smallest).
-        
-        Args:
-            original_shape: 3D shape tuple
-            
-        Returns:
-            int: index of slice dimension (0, 1, or 2)
         """
-        return np.argmin(original_shape)
+        if len(original_shape) < 3:
+            return 0
+        return int(np.argmin(original_shape))

--- a/src/ImageLoader.py
+++ b/src/ImageLoader.py
@@ -7,167 +7,134 @@ class BaseImageLoader:
     """Base class for medical image loading operations."""
 
     @staticmethod
-    def rearrange_dimensions(data):
+    def get_central_slice_index(shape):
         """
-        Ensures the slice dimension (always the smallest dimension) becomes the first dimension.
-        Transforms (z, x, y), (x, z, y), (x, y, z) -> (z, x, y) where z is the smallest dimension.
-        Maintains x, y order where y > x (height > width).
-
-        Args:
-            data: 3D numpy array with any dimension ordering
-
-        Returns:
-            numpy array with dimensions ordered as (slices, width, height) where height > width
-        """
-        # Find the slice dimension (smallest dimension)
-        original_shape = data.shape
-        slice_dim = np.argmin(original_shape)
-
-        # Get all three dimension indices
-        dims = [0, 1, 2]
-        # Get the other two dimensions (non-slice dimensions)
-        other_dims = [dim for dim in dims if dim != slice_dim]
-
-        # Ensure the two other dimensions are ordered so the larger one (height) comes last
-        if data.shape[other_dims[1]] > data.shape[other_dims[0]]:
-            # Correct order already: second dimension is larger (height > width)
-            new_order = [slice_dim, other_dims[0], other_dims[1]]  # (slices, width, height)
-        else:
-            # Need to swap to ensure height > width
-            new_order = [slice_dim, other_dims[1], other_dims[0]]  # (slices, height, width) -> will be corrected
-
-        # Apply the transpose
-        rearranged_data = np.transpose(data, new_order)
-
-        # Final verification: ensure the last dimension (height) is larger than middle dimension (width)
-        if rearranged_data.shape[2] <= rearranged_data.shape[1]:
-            # If still not correct, swap the last two dimensions
-            rearranged_data = np.transpose(rearranged_data, (0, 2, 1))
+        Determines the central slice index for a 3D volume.
+        The slice dimension is assumed to be the smallest dimension.
         
-        if rearranged_data.shape != original_shape:
-            print(f"WARNING: The original shape was changed: before {original_shape} -> now {rearranged_data.shape}.") 
-
-        return rearranged_data, original_shape
-    
-    @staticmethod
-    def normalize_orientation(image, orientation_rules):
-        """Applies consistent rotation/flip operations based on orientation rules."""
-        # Orientation normalization logic
-        pass
+        Args:
+            shape: tuple of 3D volume dimensions
+            
+        Returns:
+            int: central slice index along the slice dimension
+        """
+        slice_dim = np.argmin(shape)
+        return shape[slice_dim] // 2
 
 class NiftiLoader(BaseImageLoader):
-    """Specialized loader for NIfTI files."""
+    """Specialized loader for NIfTI files - loads in NATIVE orientation."""
     
     @staticmethod
     def load_volume(file_path, lazy=False):
-        """Loads NIfTI volume and applies dimension rearrangement."""
+        """
+        Loads NIfTI volume in its NATIVE orientation.
+        
+        Args:
+            file_path: path to NIfTI file
+            lazy: if True, uses lazy loading
+            
+        Returns:
+            tuple: (data, affine, original_shape)
+                - data: numpy array in NATIVE orientation
+                - affine: 4x4 affine transformation matrix
+                - original_shape: shape of the volume (same as data.shape)
+        """
         img = nib.load(file_path)
         if lazy:
-            data = img.dataobj  # Lazy loading
+            data = np.asarray(img.dataobj)  # Lazy loading
         else:
             data = img.get_fdata()
         
-        # Apply dimension rearrangement to ensure consistent orientation
-        data, original_shape = BaseImageLoader.rearrange_dimensions(data)
+        # NO rearrangement - keep native orientation
+        original_shape = data.shape
         return data, img.affine, original_shape
     
     @staticmethod
     def load_slice(file_path, slice_index=None):
         """
-        Optimized method to load only a specific slice from NIfTI without loading entire volume.
+        Loads a specific slice from NIfTI file in NATIVE orientation.
         
         Args:
             file_path (str): Path to NIfTI file
             slice_index (int, optional): Specific slice index. If None, loads central slice.
-            orientation_rules (dict, optional): Rules for image orientation
             
         Returns:
             tuple: (slice_data, affine, original_shape, slice_index_used)
+                - slice_data: 2D numpy array of the slice in NATIVE orientation
+                - affine: 4x4 affine matrix
+                - original_shape: 3D shape of the full volume
+                - slice_index_used: which slice was actually loaded
         """
         img = nib.load(file_path)
-        
-        # Get volume shape without loading data
         original_shape = img.shape
+        
+        # Handle 2D images
         if len(original_shape) == 2:
-            # Already 2D, just load and return
             slice_data = img.get_fdata()
-            slice_data, _ = BaseImageLoader.rearrange_dimensions(slice_data[np.newaxis, ...])
-            slice_data = slice_data[0]  # Remove singleton dimension
             return slice_data, img.affine, original_shape, 0
         
-        # For 3D/4D volumes, determine slice dimension and index
-        rearranged_shape, slice_dim = NiftiLoader._predict_slice_dimension(original_shape)
+        # For 3D volumes, find slice dimension (smallest dimension)
+        slice_dim = np.argmin(original_shape)
         
         # Calculate central slice if not specified
         if slice_index is None:
-            slice_index = rearranged_shape[slice_dim] // 2
+            slice_index = original_shape[slice_dim] // 2
         
-        # Load only the required slice using memory mapping
-        if len(original_shape) == 3:
-            # 3D volume - use direct indexing with memory mapping
-            if slice_dim == 0:
-                slice_data = img.dataobj[slice_index, :, :]
-            elif slice_dim == 1:
-                slice_data = img.dataobj[:, slice_index, :]
-            else:  # slice_dim == 2
-                slice_data = img.dataobj[:, :, slice_index]
+        # Validate slice index
+        if slice_index < 0 or slice_index >= original_shape[slice_dim]:
+            raise ValueError(f"Slice index {slice_index} out of range for dimension {slice_dim} with size {original_shape[slice_dim]}")
         
-        # Convert to array and ensure proper dtype
-        slice_data = np.asarray(slice_data)
+        # Load only the required slice using memory mapping (efficient)
+        # Extract slice based on which dimension contains slices
+        if slice_dim == 0:
+            slice_data = np.asarray(img.dataobj[slice_index, :, :])
+        elif slice_dim == 1:
+            slice_data = np.asarray(img.dataobj[:, slice_index, :])
+        else:  # slice_dim == 2
+            slice_data = np.asarray(img.dataobj[:, :, slice_index])
         
-        # Apply dimension rearrangement to 2D slice
-        slice_2d = slice_data[np.newaxis, ...]  # Add batch dimension
-        rearranged, _ = BaseImageLoader.rearrange_dimensions(slice_2d)
-        slice_data = rearranged[0]  # Remove batch dimension
-        print(f"slice_data dim:{slice_data.shape}")
         return slice_data, img.affine, original_shape, slice_index
 
-    @staticmethod
-    def _predict_slice_dimension(shape):
-        """
-        Predicts which dimension contains slices without loading data.
-        Returns rearranged shape and slice dimension index.
-        """
-        if len(shape) == 2:
-            return shape, 0
-        
-        # Create a dummy array with the same shape to test rearrangement
-        dummy_data = np.zeros(shape)
-        rearranged, _ = BaseImageLoader.rearrange_dimensions(dummy_data)
-        slice_dim = np.argmin(rearranged.shape)
-        
-        return rearranged.shape, slice_dim
-
 class DicomLoader(BaseImageLoader):
-    """Specialized loader for DICOM series."""
+    """Specialized loader for DICOM series - loads in NATIVE orientation."""
     
     @staticmethod
     def load_series(folder_path):
-        """Loads DICOM series and applies dimension rearrangement."""
+        """
+        Loads DICOM series in NATIVE orientation (no rearrangement).
+        
+        Args:
+            folder_path: path to folder containing DICOM files
+            
+        Returns:
+            tuple: (volume, affine, original_shape)
+        """
         # Load DICOM files
         dicom_files = [os.path.join(folder_path, f) for f in os.listdir(folder_path)
                       if f.lower().endswith(('.dcm', '.dicom'))]
+        
+        if not dicom_files:
+            raise FileNotFoundError(f"No DICOM files found in {folder_path}")
         
         # Sort and load slices
         dicoms = [pydicom.dcmread(f) for f in dicom_files]
         dicoms.sort(key=lambda d: int(getattr(d, "InstanceNumber", 0)))
         
-        # Create 3D volume from slices
+        # Create 3D volume from slices - native stacking (no rearrangement)
         volume = np.stack([d.pixel_array for d in dicoms], axis=0)
         
-        # Apply dimension rearrangement
-        volume, original_shape = BaseImageLoader.rearrange_dimensions(volume)
-        return volume, np.eye(4), original_shape  # Return identity matrix as affine for DICOM
+        # Return identity matrix as affine for DICOM (could compute real affine from metadata)
+        original_shape = volume.shape
+        return volume, np.eye(4), original_shape
     
     @staticmethod
     def load_slice(folder_path, slice_index=None):
         """
-        Optimized method to load only a specific slice from DICOM series.
+        Loads a specific slice from DICOM series.
         
         Args:
             folder_path (str): Path to DICOM directory
             slice_index (int, optional): Specific slice index. If None, loads central slice.
-            orientation_rules (dict, optional): Rules for image orientation
             
         Returns:
             tuple: (slice_data, affine, original_shape, slice_index_used)
@@ -182,104 +149,42 @@ class DicomLoader(BaseImageLoader):
         # Sort by InstanceNumber without loading pixel data
         dicoms = []
         for file_path in dicom_files:
-            ds = pydicom.dcmread(file_path, stop_before_pixels=True)  # Fast metadata only
+            ds = pydicom.dcmread(file_path, stop_before_pixels=True)
             dicoms.append((file_path, ds))
         
         dicoms.sort(key=lambda x: int(getattr(x[1], "InstanceNumber", 0)))
         
+        # Get total number of slices and image dimensions
+        num_slices = len(dicoms)
+        
         # Calculate central slice if not specified
         if slice_index is None:
-            slice_index = len(dicoms) // 2
-        elif slice_index >= len(dicoms):
-            raise ValueError(f"Slice index {slice_index} out of range. Series has {len(dicoms)} slices.")
+            slice_index = num_slices // 2
+        elif slice_index >= num_slices:
+            raise ValueError(f"Slice index {slice_index} out of range. Series has {num_slices} slices.")
         
-        # Load only the required slice's pixel data
-        file_path, ds_meta = dicoms[slice_index]
-        ds_full = pydicom.dcmread(file_path)  # Now load with pixel data
-        slice_data = ds_full.pixel_array.astype(np.float32)
+        # Load only the specific slice
+        target_file = dicoms[slice_index][0]
+        ds = pydicom.dcmread(target_file)
+        slice_data = ds.pixel_array.astype(np.float32)
         
-        # Get original volume shape from metadata
-        num_slices = len(dicoms)
-        rows = ds_full.Rows
-        cols = ds_full.Columns
+        # Get dimensions from first slice to build original_shape
+        rows = ds.Rows
+        cols = ds.Columns
         original_shape = (num_slices, rows, cols)
-        
-        # Create 3D-like array for dimension rearrangement
-        volume_like = slice_data[np.newaxis, ...]  # Add slice dimension
-        rearranged, _ = BaseImageLoader.rearrange_dimensions(volume_like)
-        slice_data = rearranged[0]  # Remove slice dimension
         
         return slice_data, np.eye(4), original_shape, slice_index
 
     @staticmethod
     def load_single_file(file_path):
         """
-        Loads a single DICOM file (either 2D slice or multi-frame volume).
+        Loads a single DICOM file (2D slice or multi-frame volume).
 
         Args:
-            file_path (str): Path to a DICOM file (.dcm, .dicom)
+            file_path (str): Path to DICOM file (.dcm, .dicom)
 
         Returns:
             tuple: (volume, affine, original_shape)
-                - volume: np.ndarray (after rearrange_dimensions)
-                - affine: np.ndarray (4x4) - identity for now
-                - original_shape: tuple (before rearrange_dimensions)
-        """
-        if not os.path.isfile(file_path):
-            raise FileNotFoundError(f"DICOM file not found: {file_path}")
-
-        if not file_path.lower().endswith((".dcm", ".dicom")):
-            raise ValueError(f"Not a DICOM file extension: {file_path}")
-
-        ds = pydicom.dcmread(file_path)
-
-        # Some DICOMs can be missing pixel data (e.g., RTSTRUCT, SR, etc.)
-        if "PixelData" not in ds:
-            raise ValueError(f"DICOM has no PixelData (not an image): {file_path}")
-
-        arr = ds.pixel_array  # may be 2D, 3D (multiframe), or sometimes 4D (rare)
-
-        # Normalize to a 3D "volume-like" array: (Z, Y, X)
-        print(f"The DICOM dim: {arr.ndim}")
-        if arr.ndim == 2:
-            volume = arr[np.newaxis, ...]  # (1, H, W)
-        elif arr.ndim == 3:
-            # Typically (n_frames, H, W) for multiframe
-            volume = arr
-        elif arr.ndim == 4:
-            # Some modalities/encodings can yield (n_frames, H, W, channels)
-            # For medical grayscale data, channels is often 1; handle conservatively:
-            if arr.shape[-1] == 1:
-                volume = arr[..., 0]
-            else:
-                raise ValueError(
-                    f"Unsupported 4D DICOM pixel array shape {arr.shape} in {file_path}. "
-                    "If this is RGB, you'll need a policy (e.g., convert to grayscale or keep channels)."
-                )
-        else:
-            raise ValueError(f"Unsupported DICOM pixel array ndim={arr.ndim} for file {file_path}")
-
-        volume = volume.astype(np.float32)
-
-        original_shape = volume.shape  # (Z, Y, X) before rearrange
-        volume, _ = BaseImageLoader.rearrange_dimensions(volume)
-
-        # TODO: If you want a real affine, you can compute it from:
-        # ImagePositionPatient, ImageOrientationPatient, PixelSpacing, SliceThickness/SpacingBetweenSlices
-        affine = np.eye(4, dtype=np.float32)
-
-        return volume, affine, original_shape
-
-    @staticmethod
-    def load_single_slice(file_path, slice_index=None):
-        """
-        Load a slice from a single DICOM file.
-        Works for:
-          - 2D single-slice DICOM  -> returns that slice (index 0)
-          - multi-frame DICOM (3D) -> returns selected frame
-
-        Returns:
-            (slice_data, affine, original_shape, slice_index_used)
         """
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"DICOM file not found: {file_path}")
@@ -294,76 +199,104 @@ class DicomLoader(BaseImageLoader):
 
         arr = ds.pixel_array
 
-        # Case A: single 2D image
+        # Normalize to 3D volume
         if arr.ndim == 2:
-            # Only one "slice" exists
-            if slice_index is None:
+            volume = arr[np.newaxis, ...].astype(np.float32)  # (1, H, W)
+        elif arr.ndim == 3:
+            volume = arr.astype(np.float32)  # (n_frames, H, W)
+        elif arr.ndim == 4 and arr.shape[-1] == 1:
+            volume = arr[..., 0].astype(np.float32)
+        else:
+            raise ValueError(f"Unsupported DICOM pixel array shape {arr.shape}")
+
+        original_shape = volume.shape
+        affine = np.eye(4, dtype=np.float32)
+
+        return volume, affine, original_shape
+
+    @staticmethod
+    def load_single_slice(file_path, slice_index=None):
+        """
+        Loads a slice from a single DICOM file.
+        
+        Args:
+            file_path: path to DICOM file
+            slice_index: specific slice/frame index
+            
+        Returns:
+            tuple: (slice_data, affine, original_shape, slice_index_used)
+        """
+        if not os.path.isfile(file_path):
+            raise FileNotFoundError(f"DICOM file not found: {file_path}")
+
+        if not file_path.lower().endswith((".dcm", ".dicom")):
+            raise ValueError(f"Not a DICOM file extension: {file_path}")
+
+        ds = pydicom.dcmread(file_path)
+
+        if "PixelData" not in ds:
+            raise ValueError(f"DICOM has no PixelData: {file_path}")
+
+        arr = ds.pixel_array
+
+        # Case A: Single 2D image
+        if arr.ndim == 2:
+            if slice_index is None or slice_index == 0:
                 slice_index_used = 0
             else:
-                if slice_index != 0:
-                    raise ValueError(
-                        f"slice_index={slice_index} invalid for 2D single-file DICOM. Use 0."
-                    )
-                slice_index_used = slice_index
-
+                raise ValueError(f"slice_index={slice_index} invalid for 2D DICOM. Use 0.")
+            
             slice_data = arr.astype(np.float32)
-            original_shape = (1, slice_data.shape[0], slice_data.shape[1])  # (Z=1, H, W)
-
-            # Use your rearrange pipeline (expects 3D)
-            volume_like = slice_data[np.newaxis, ...]  # (1, H, W)
-            rearranged, _ = BaseImageLoader.rearrange_dimensions(volume_like)
-            slice_data = rearranged[0]
-
+            original_shape = (1, slice_data.shape[0], slice_data.shape[1])
             return slice_data, np.eye(4, dtype=np.float32), original_shape, slice_index_used
 
-        # Case B: multi-frame (typically (n_frames, H, W))
+        # Case B: Multi-frame 3D
         if arr.ndim == 3:
             n_frames = arr.shape[0]
-
+            
             if slice_index is None:
                 slice_index_used = n_frames // 2
             else:
                 if slice_index < 0 or slice_index >= n_frames:
-                    raise ValueError(
-                        f"Slice index {slice_index} out of range. File has {n_frames} frames."
-                    )
+                    raise ValueError(f"Slice index {slice_index} out of range. File has {n_frames} frames.")
                 slice_index_used = slice_index
-
-            frame = arr[slice_index_used].astype(np.float32)  # (H, W)
-            original_shape = (n_frames, frame.shape[0], frame.shape[1])
-
-            volume_like = frame[np.newaxis, ...]  # (1, H, W)
-            rearranged, _ = BaseImageLoader.rearrange_dimensions(volume_like)
-            slice_data = rearranged[0]
-
+            
+            slice_data = arr[slice_index_used].astype(np.float32)
+            original_shape = (n_frames, slice_data.shape[0], slice_data.shape[1])
             return slice_data, np.eye(4, dtype=np.float32), original_shape, slice_index_used
 
-        # Optional: handle 4D (rare)
+        # Case C: 4D with single channel
         if arr.ndim == 4 and arr.shape[-1] == 1:
             arr = arr[..., 0]
-            # then treat as 3D above
             n_frames = arr.shape[0]
             slice_index_used = n_frames // 2 if slice_index is None else slice_index
+            
             if slice_index_used < 0 or slice_index_used >= n_frames:
                 raise ValueError(f"Slice index {slice_index_used} out of range. File has {n_frames} frames.")
-            frame = arr[slice_index_used].astype(np.float32)
-            original_shape = (n_frames, frame.shape[0], frame.shape[1])
-
-            volume_like = frame[np.newaxis, ...]
-            rearranged, _ = BaseImageLoader.rearrange_dimensions(volume_like)
-            slice_data = rearranged[0]
-
+            
+            slice_data = arr[slice_index_used].astype(np.float32)
+            original_shape = (n_frames, slice_data.shape[0], slice_data.shape[1])
             return slice_data, np.eye(4, dtype=np.float32), original_shape, slice_index_used
 
-        raise ValueError(f"Unsupported DICOM pixel array ndim={arr.ndim} for file {file_path}")
+        raise ValueError(f"Unsupported DICOM pixel array ndim={arr.ndim}")
 
-    
 
 class UnifiedImageLoader:
-    """Unified Interface for all formats"""
+    """
+    Unified interface for loading medical images in their NATIVE orientation.
+    
+    Key principle: Load images as-is, apply transformations only for display,
+    and always save in native orientation with correct affine matrix.
+    """
 
     @staticmethod
     def load_image(file_path):
+        """
+        Load complete volume in native orientation.
+        
+        Returns:
+            tuple: (volume, affine, original_shape)
+        """
         if os.path.isdir(file_path):
             return DicomLoader.load_series(file_path)
         elif file_path.lower().endswith(('.dcm', '.dicom')):
@@ -371,17 +304,16 @@ class UnifiedImageLoader:
         elif file_path.lower().endswith(('.nii', '.nii.gz')):
             return NiftiLoader.load_volume(file_path)
         else:
-            raise ValueError(f"Format is not supported: {file_path}")
+            raise ValueError(f"Unsupported format: {file_path}")
         
     @staticmethod
     def load_slice(file_path, slice_index=None):
         """
-        Optimized method to load only a specific slice without loading entire volume.
+        Load a specific slice in native orientation.
         
         Args:
-            file_path (str): Path to NIfTI file or DICOM directory
-            slice_index (int, optional): Specific slice index. If None, loads central slice.
-            orientation_rules (dict, optional): Rules for image orientation
+            file_path: path to image file or DICOM directory
+            slice_index: specific slice index (None = central slice)
             
         Returns:
             tuple: (slice_data, affine, original_shape, slice_index_used)
@@ -393,4 +325,17 @@ class UnifiedImageLoader:
         elif file_path.lower().endswith(('.nii', '.nii.gz')):
             return NiftiLoader.load_slice(file_path, slice_index)
         else:
-            raise ValueError(f"Format is not supported: {file_path}")
+            raise ValueError(f"Unsupported format: {file_path}")
+    
+    @staticmethod
+    def get_slice_dimension(original_shape):
+        """
+        Identifies which dimension contains slices (usually the smallest).
+        
+        Args:
+            original_shape: 3D shape tuple
+            
+        Returns:
+            int: index of slice dimension (0, 1, or 2)
+        """
+        return np.argmin(original_shape)

--- a/src/batch_draw_step.py
+++ b/src/batch_draw_step.py
@@ -300,7 +300,8 @@ def batch_draw_step():
                     original_shape=st.session_state["original_shape"],
                     affine=st.session_state["affine"],
                     img_type=st.session_state["img_type"],
-                    file_path=st.session_state["output_path"]
+                    file_path=st.session_state["output_path"],
+                    original_image_path=st.session_state["original_image_path"],
                 )
                 
                 # Mark file as completed

--- a/src/batch_draw_step.py
+++ b/src/batch_draw_step.py
@@ -1,19 +1,18 @@
-
 # =========================
 # Imports
 # =========================
 import os
 import streamlit as st
 from PIL import Image
-from new_utils import ImageProcessor, MaskManager
+from new_utils import ImageProcessor, MaskManager, DisplayTransform
 from ImageLoader import UnifiedImageLoader
 from streamlit_drawable_canvas import st_canvas
 import numpy as np
 
 def batch_draw_step():
     """
-    Main function for Step 2: Draw Masks in batch mode.
-    Handles navigation, drawing, mask creation, and saving for each file in the batch.
+    Step 2: Draw Masks in batch mode.
+    Uses DisplayTransform to properly handle coordinate transformations.
     """
 
     # =========================
@@ -38,8 +37,8 @@ def batch_draw_step():
     # =========================
     batch_files = st.session_state["batch_files"]
     current_index = st.session_state.get("batch_current_index", 0)
-    all_completed_draw = st.session_state["batch_completed_files"]["draw"]  # All files with a polygon
-    completed_draw = [f for f in all_completed_draw if f in st.session_state["batch_files_without_extension"]]  # Only batch files with a polygon
+    all_completed_draw = st.session_state["batch_completed_files"]["draw"]
+    completed_draw = [f for f in all_completed_draw if f in st.session_state["batch_files_without_extension"]]
 
     # =========================
     # Progress Bar
@@ -78,17 +77,20 @@ def batch_draw_step():
     # =========================
     st.markdown(f"""
     <div class="current-file">
-        <h4>📁 {current_file} ({current_index + 1}/{total_files})</h4>
+        <h4>📄 {current_file} ({current_index + 1}/{total_files})</h4>
         <p>💡 Navigate between unsaved files • Saved files are locked</p>
     </div>
     """, unsafe_allow_html=True)
+    
     # --- Navigation Buttons ---
     col1, col2, col3 = st.columns([1, 2, 1])
     with col1:
         if current_index > 0 and st.button("← Previous", help="Navigate to previous unsaved file"):
             st.session_state["batch_current_index"] = current_index - 1
             # Clear current file session state
-            keys_to_clear = ["points", "mask", "result", "create_mask", "affine", "original_image_path", "nb_of_slices", "scale", "output_path"]
+            keys_to_clear = ["display_transform", "mask", "result", "create_mask", 
+                           "affine", "original_image_path", "slice_index", "output_path",
+                           "original_shape", "native_polygons"]
             for key in keys_to_clear:
                 if key in st.session_state:
                     del st.session_state[key]
@@ -99,7 +101,9 @@ def batch_draw_step():
         if next_file_index < len(batch_files) and st.button("Next →", help="Navigate to next unsaved file"):
             st.session_state["batch_current_index"] = next_file_index
             # Clear current file session state
-            keys_to_clear = ["points", "mask", "result", "create_mask", "affine", "original_image_path", "nb_of_slices", "scale", "output_path"]
+            keys_to_clear = ["display_transform", "mask", "result", "create_mask",
+                           "affine", "original_image_path", "slice_index", "output_path",
+                           "original_shape", "native_polygons"]
             for key in keys_to_clear:
                 if key in st.session_state:
                     del st.session_state[key]
@@ -119,7 +123,6 @@ def batch_draw_step():
     # =========================
     # File Loading & Preparation
     # =========================
-    # Use the selected main input folder from session_state
     input_folder = st.session_state.get("main_input_folder", os.path.join(os.getcwd(), "media"))
     file_path = os.path.join(input_folder, current_file)
 
@@ -130,52 +133,39 @@ def batch_draw_step():
         st.error(f"File not found: {file_path}")
         return
 
-    # Load image and metadata
-    #image, affine, nb_of_slices = ImageOperations.load_image(file_path)
-    volume, affine, original_shape = UnifiedImageLoader.load_image(file_path)
-    internal_volume_shape = volume.shape 
-    nb_of_slices= internal_volume_shape[0]
-    image = volume[internal_volume_shape[0]//2, :, :] # loading the central slice as image
-    print(f"original shape:{original_shape}")
-    print(f"internal_volume_shape:{internal_volume_shape}")
-    print(f"image shape: {image.shape}")
-    del volume # removing volume to not consume RAM
+    # Load image in NATIVE orientation
+    image_slice, affine, original_shape, slice_index = UnifiedImageLoader.load_slice(file_path)
+    
+    print(f"=== File: {current_file} ===")
+    print(f"Original shape: {original_shape}")
+    print(f"Loaded slice shape: {image_slice.shape}")
+    print(f"Slice index: {slice_index}")
+    print(f"Slice dimension: {np.argmin(original_shape)}")
 
     # Initialize session state for new file
-    if "affine" not in st.session_state or st.session_state.get("current_batch_file") != current_file:
+    if "original_image_path" not in st.session_state or st.session_state.get("current_batch_file") != current_file:
         st.session_state["affine"] = affine
         st.session_state["original_image_path"] = file_path
-        st.session_state["nb_of_slices"] = nb_of_slices
+        st.session_state["original_shape"] = original_shape
+        st.session_state["slice_index"] = slice_index
         st.session_state["current_batch_file"] = current_file
-        st.session_state["points"] = []  # Reset points for new file
-        st.session_state["polygons"] = []
+        st.session_state["native_polygons"] = []
         # Clear other file-specific data
-        for key in ["mask", "result", "create_mask"]:
+        for key in ["mask", "result", "create_mask", "display_transform"]:
             if key in st.session_state:
                 del st.session_state[key]
 
     # =========================
-    # Image Scaling & Canvas Setup
+    # Display Transformation Setup
     # =========================
-    max_width, max_height = 1200, 800
-    orig_height, orig_width = image.shape[0], image.shape[1]
-    scale = min(max_width / orig_width, max_height / orig_height, 1)
-    if "scale" not in st.session_state:
-        st.session_state["scale"] = scale
-
-    # Pad image to avoid edge issues 
-    padding = 50
-    padded_image = np.pad(image,
-                           pad_width=((padding, padding), (padding, padding)),
-                            mode="constant", constant_values=0)
-    padded_image = ImageProcessor.normalize_image(padded_image) 
+    if "display_transform" not in st.session_state:
+        st.session_state["display_transform"] = DisplayTransform(padding=50)
     
-    pil_height = int(padded_image.shape[0] * scale)
-    pil_width = int(padded_image.shape[1] * scale)    
-    pil_image = Image.fromarray(padded_image).resize((pil_width, pil_height)).rotate(90, expand=True)
+    transform = st.session_state["display_transform"]
     
-    if "points" not in st.session_state:
-        st.session_state.points = []
+    # Prepare image for display
+    pil_image = transform.prepare_for_display(image_slice, max_width=1200, max_height=800)
+    rotated_width, rotated_height = pil_image.size
 
     # --- Drawing Canvas ---
     st.markdown("### 🖌️ Drawing Canvas")
@@ -208,9 +198,6 @@ def batch_draw_step():
     </small>
     """, unsafe_allow_html=True)
 
-
-    
-    rotated_width, rotated_height = pil_image.size
     canvas_result = st_canvas(
         fill_color="rgba(255, 0, 0, 0.3)",
         stroke_width=2,
@@ -240,53 +227,53 @@ def batch_draw_step():
     # =========================
     if canvas_result.json_data is not None:
         objects = canvas_result.json_data["objects"]
-        polygons = []
         
         # If canvas was cleared (no objects), clear all related state
         if len(objects) == 0:
-            st.session_state.polygons = []
+            st.session_state["native_polygons"] = []
             # Clear mask-related state if it exists
             for key in ["mask", "result", "create_mask"]:
                 if key in st.session_state:
                     del st.session_state[key]
         else:
-            # Process polygons from canvas
+            # Extract polygons from canvas and convert to native coordinates
+            native_polygons = []
+            
             for obj in objects:
-                if obj["type"] == "path":  # ensure it's a polygon
+                if obj["type"] == "path":
                     poly = obj["path"]
-                    points_rotated = [(int(p[1]), int(p[2])) for p in poly if len(p) == 3]
-                    points = []
-                    for x, y in points_rotated:
-                        # removing rotation
-                        px, py = rotated_height - y, x
-
-                        # padding removing
-                        px -= int(padding*scale)
-                        py -= int(padding*scale)
-
-                        # scaling back to original image size
-                        px = min(max(px, 0), image.shape[0] - 1)
-                        py = min(max(py, 0), image.shape[1] - 1)
-
-                        points.append((px, py))
-                    polygons.append(points)
-
-            # Save all polygons to session state
-            st.session_state.polygons = polygons
+                    # Extract canvas coordinates
+                    canvas_points = [(int(p[1]), int(p[2])) for p in poly if len(p) == 3]
+                    
+                    # Convert to native image coordinates using DisplayTransform
+                    native_points = transform.canvas_to_native_coords(
+                        canvas_points, rotated_width, rotated_height
+                    )
+                    
+                    if len(native_points) >= 3:
+                        native_polygons.append(native_points)
+            
+            # Save native polygons to session state
+            st.session_state["native_polygons"] = native_polygons
 
     # =========================
     # Mask Creation Logic
     # =========================
     if st.session_state.get("create_mask", False):
-        if "polygons" in st.session_state and len(st.session_state.polygons) > 0:
-            result, combined_mask = MaskManager.create_combined_mask(image, st.session_state.polygons, scale)
+        if "native_polygons" in st.session_state and len(st.session_state["native_polygons"]) > 0:
+            # Create mask in NATIVE orientation
+            result, combined_mask = MaskManager.create_combined_mask(
+                image_slice, 
+                st.session_state["native_polygons"]
+            )
+            
             st.session_state["mask"] = combined_mask
             st.session_state["result"] = result
             st.session_state["output_path"] = os.path.join(os.getcwd(), 'output', current_file_name)
             st.session_state["create_mask"] = False
             st.rerun()
         else:
-            st.warning("Select at least 3 points to create a polygon.")
+            st.warning("Please draw at least one polygon with 3 or more points.")
             st.session_state["create_mask"] = False
 
     # =========================
@@ -296,7 +283,8 @@ def batch_draw_step():
         st.markdown("### 👁️ Mask Preview")
         col1, col2 = st.columns(2)
 
-        present_img = ImageProcessor.normalize_image(np.rot90(image))
+        # Display with rotation for visualization consistency
+        present_img = ImageProcessor.normalize_image(np.rot90(image_slice))
         present_result = ImageProcessor.normalize_image(np.rot90(st.session_state["result"]))
 
         with col1:
@@ -307,24 +295,27 @@ def batch_draw_step():
         col1, col2, col3 = st.columns([1, 1, 1])
         with col2:
             if st.button("💾 Save Mask & Continue", type="primary"):
-                # Save mask exactly as drawn, no rotation or transformation
+                # Save mask in NATIVE orientation with proper dimension handling
                 _ = MaskManager.save_mask(
-                        mask=st.session_state["mask"],
-                        original_shape=original_shape,
-                        nb_of_slices=st.session_state["nb_of_slices"],
-                        affine=st.session_state["affine"],
-                        file_path=st.session_state["output_path"],
-                        #points=st.session_state["points"], in old version we save a .json file with the points and scale info
-                        #scale=st.session_state["scale"]
-                    )
+                    mask_2d=st.session_state["mask"],
+                    original_shape=st.session_state["original_shape"],
+                    affine=st.session_state["affine"],
+                    file_path=st.session_state["output_path"]
+                )
+                
                 # Mark file as completed
                 st.session_state["batch_completed_files"]["draw"].append(current_file_name)
+                
                 # Move to next file
                 st.session_state["batch_current_index"] = current_index + 1
+                
                 # Clear current file session state
-                keys_to_clear = ["points", "mask", "result", "create_mask", "affine", "original_image_path", "nb_of_slices", "scale", "output_path", "current_batch_file"]
+                keys_to_clear = ["display_transform", "mask", "result", "create_mask",
+                               "affine", "original_image_path", "slice_index", "output_path",
+                               "original_shape", "current_batch_file", "native_polygons"]
                 for key in keys_to_clear:
                     if key in st.session_state:
                         del st.session_state[key]
+                
                 st.success(f"Mask saved for {current_file}!")
                 st.rerun()

--- a/src/batch_process_step.py
+++ b/src/batch_process_step.py
@@ -58,9 +58,9 @@ class BatchProcessingManager:
                 raise FileNotFoundError(f"Mask not found: {mask_path}")
             
             # Load central slice to calculate target area
-            central_image_slice, original_affine, original_shape, central_slice_idx = \
+            central_image_slice, original_affine, original_shape, central_slice_idx, _ = \
                 UnifiedImageLoader.load_slice(original_image_path)
-            central_mask_slice, _, _, _ = UnifiedImageLoader.load_slice(mask_path, central_slice_idx)
+            central_mask_slice, _, _, _, _ = UnifiedImageLoader.load_slice(mask_path, central_slice_idx)
             
             # Calculate target area from central slice
             thresholded_img = ThresholdOperator.threshold_slice(
@@ -132,10 +132,10 @@ class BatchProcessingManager:
             for slice_index in range(start_idx, end_idx):
                 try:
                     # Load slice in NATIVE orientation
-                    image_slice, _, _, _ = UnifiedImageLoader.load_slice(
+                    image_slice, _, _, _, _ = UnifiedImageLoader.load_slice(
                         original_image_path, slice_index
                     )
-                    mask_slice, _, _, _ = UnifiedImageLoader.load_slice(
+                    mask_slice, _, _, _, _ = UnifiedImageLoader.load_slice(
                         mask_path, slice_index
                     )
                     

--- a/src/batch_process_step.py
+++ b/src/batch_process_step.py
@@ -296,6 +296,8 @@ def batch_process_step():
     
     completed_threshold = st.session_state["batch_completed_files"]["threshold"]
     completed_process = st.session_state["batch_completed_files"]["process"]
+    batch_files_without_extension = [f.split('.')[0] for f in batch_files]
+    completed_process_filtered = [f for f in completed_process if f in batch_files_without_extension]
     
     # Filter files that have thresholds but not yet processed
     files_to_process = []
@@ -308,14 +310,14 @@ def batch_process_step():
     # Progress Display
     # =========================
     total_files = len(batch_files)
-    st.write(f"### Progress: {len(completed_process)}/{total_files} files processed")
-    st.progress(len(completed_process) / total_files)
+    st.write(f"### Progress: {len(completed_process_filtered)}/{total_files} files processed")
+    st.progress(len(completed_process_filtered) / total_files)
     st.markdown('</div>', unsafe_allow_html=True)
     
     # =========================
     # All Files Processed Message
     # =========================
-    if len(files_to_process) == 0 and len(completed_process) == total_files:
+    if len(files_to_process) == 0 and len(completed_process_filtered) == total_files:
         st.markdown("""
         <div class="success-container">
             <h4>🎉 All files have been processed successfully!</h4>

--- a/src/batch_threshold_step.py
+++ b/src/batch_threshold_step.py
@@ -156,9 +156,9 @@ def batch_threshold_step():
         return
 
     try:
-        img, _, _, _ = UnifiedImageLoader.load_slice(original_image_path)
+        img, _, _, _, _ = UnifiedImageLoader.load_slice(original_image_path)
         img_show = np.rot90(ImageProcessor.normalize_image(img)) # to show on GUI
-        msk, _, _, _ = UnifiedImageLoader.load_slice(mask_path)
+        msk, _, _, _, _ = UnifiedImageLoader.load_slice(mask_path)
         msk_show = np.rot90(msk)
     except Exception as e:
         st.error(f"Error loading images: {str(e)}")

--- a/src/batch_threshold_step.py
+++ b/src/batch_threshold_step.py
@@ -5,7 +5,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import streamlit as st
 from ImageLoader import UnifiedImageLoader
-from new_utils import ThresholdOperator, ImageProcessor
+from new_utils import ThresholdOperator, ImageProcessor, resolve_dense_mask_path
 
 
 def batch_threshold_step():
@@ -136,8 +136,9 @@ def batch_threshold_step():
     # Use main input folder selected in Step 1
     input_folder = st.session_state.get("main_input_folder", os.path.join(os.getcwd(), "media"))
     output_path = os.path.join(os.getcwd(), "output", current_file_name)
-    mask_path = os.path.join(output_path, "dense.nii")
     original_image_path = os.path.join(input_folder, current_file)
+    is_dicom = os.path.isdir(original_image_path) or original_image_path.lower().endswith((".dcm", ".dicom"))
+    mask_path = resolve_dense_mask_path(output_path, prefer_dicom=is_dicom)
 
     if not os.path.exists(input_folder):
         st.error(f"The selected main input folder does not exist: {input_folder}")
@@ -147,8 +148,8 @@ def batch_threshold_step():
     # =====================================================
     # File existence and image loading 
     # =====================================================
-    if not os.path.exists(mask_path):
-        st.error(f"Mask file not found: {mask_path}")
+    if mask_path is None:
+        st.error("Mask file not found for this case.")
         st.write("This file may not have completed the draw step properly.")
         if st.button("Skip this file"):
             st.session_state["batch_current_index"] = current_index + 1

--- a/src/file_selection_step.py
+++ b/src/file_selection_step.py
@@ -1,6 +1,7 @@
 import os
 import streamlit as st
 import json
+from new_utils import resolve_dense_mask_path, resolve_final_mask_path
 
 
 # =============================
@@ -56,9 +57,8 @@ def file_selection_step():
             if not os.path.isdir(folder_path):
                 continue
 
-            # Draw step: completed if dense.nii exists
-            dense_path = os.path.join(folder_path, "dense.nii")
-            if os.path.exists(dense_path):
+            # Draw step: completed if dense mask exists (NIfTI or DICOM)
+            if resolve_dense_mask_path(folder_path) is not None:
                 actual_progress["draw"].append(folder_name)
 
             # Threshold step: completed if threshold.json exists and contains 'threshold'
@@ -72,9 +72,8 @@ def file_selection_step():
                 except Exception as e:
                     st.warning(f"Could not read threshold for {folder_name}: {e}")
 
-            # Process step: completed if mask.nii exists in dense_mask subfolder
-            mask_path = os.path.join(folder_path, "dense_mask", "mask.nii")
-            if os.path.exists(mask_path):
+            # Process step: completed if final mask exists (NIfTI or DICOM)
+            if resolve_final_mask_path(folder_path) is not None:
                 actual_progress["process"].append(folder_name)
 
     st.session_state["batch_completed_files"] = actual_progress

--- a/src/new_utils.py
+++ b/src/new_utils.py
@@ -293,8 +293,8 @@ class MaskManager:
         
         os.makedirs(file_path, exist_ok=True)
 
-        # Ensure binary values (0/1) for saved mask
-        mask_2d = (mask_2d > 0).astype(np.uint8)
+        # Ensure binary values (0/255) for saved mask (better overlay visibility)
+        mask_2d = (mask_2d > 0).astype(np.uint8) * 255
 
         if img_type == "DICOM":
             print("Detected DICOM image!")
@@ -390,7 +390,7 @@ class MaskManager:
     @staticmethod
     def _save_dicom_mask(mask_3d, source_path, output_dir, base_name):
         os.makedirs(output_dir, exist_ok=True)
-        mask_3d = (mask_3d > 0).astype(np.uint8)
+        mask_3d = (mask_3d > 0).astype(np.uint8) * 255
         series_desc = f"{base_name} mask"
 
         if os.path.isdir(source_path):
@@ -524,7 +524,7 @@ class MaskManager:
         for f in npy_files:
             array = np.load(os.path.join(folder_path, f))
             # Convert to binary (0 or 1)
-            binary_slice = (array > 0).astype(np.uint8)
+            binary_slice = (array > 0).astype(np.uint8) * 255
             slices.append(binary_slice)
         
         print(f"Original shape: {original_shape}")

--- a/src/new_utils.py
+++ b/src/new_utils.py
@@ -3,15 +3,15 @@ import nibabel as nib
 import os
 import cv2
 import matplotlib.pyplot as plt
-import nibabel as nib
 
 
 class ImageProcessor:
     """Image processing operations"""
+    
     @staticmethod
     def normalize_image(img):
         """
-            Return the image in 0-255 range
+        Return the image in 0-255 range for display.
         """
         img = img - np.min(img)
         img = img / (np.max(img) + 1e-8)
@@ -20,377 +20,350 @@ class ImageProcessor:
     @staticmethod
     def normalize_data(data):
         """
-            Return data in 0-1 range
+        Return data in 0-1 range.
         """
         mn, mx = data.min(), data.max()
+        if mx == mn:
+            return np.zeros_like(data)
         return (data - mn) / (mx - mn)
 
-class MaskManager:
-    """Mask-specific operations"""
-    @staticmethod
-    def create_mask(image, points, reduction_scale=1.0):
+
+class DisplayTransform:
+    """
+    Tracks and applies/reverses display transformations.
+    
+    Key principle: Keep images in native orientation, only transform for display,
+    and properly inverse transform coordinates back to native space.
+    """
+    
+    def __init__(self, padding=50):
         """
-        Creates a binary mask from a polygon defined by points and applies it to an image.
-
-        This method generates a polygon mask based on the provided points, scales them 
-        according to the reduction scale, and returns both the masked image and the binary mask.
-        Useful for single-region segmentation tasks.
-
-        Args:
-            image (numpy.ndarray): Input image to apply the mask to. Can be grayscale or RGB.
-            points (list of tuples): Polygon coordinates as [(x1,y1), (x2,y2), ...] 
-                                    in reduced scale coordinates.
-            reduction_scale (float, optional): Scale factor used to reduce the original image. 
-                                             Points will be scaled up by 1/reduction_scale.
-                                             Defaults to 1.0 (no scaling).
-
-        Returns:
-            tuple: A tuple containing:
-                - masked_image (numpy.ndarray): Original image with mask applied 
-                                              (areas outside mask are blackened).
-                - binary_mask (numpy.ndarray): Binary mask where polygon area is white (255) 
-                                             and background is black (0).
-
-        Raises:
-            ValueError: If fewer than 3 points are provided (insufficient for a polygon).
-
-        Example:
-            -> points = [(100, 100), (150, 100), (125, 150)]
-            -> masked_img, mask = MaskManager.create_mask(image, points, reduction_scale=0.5)
-            -> print(mask.shape)  # Same as image shape
-            -> print(np.unique(mask))  # [0, 255]
-        """
+        Initialize display transformation tracker.
         
+        Args:
+            padding: padding pixels to add around image
+        """
+        self.padding = padding
+        self.scale = 1.0
+        self.padded_shape = None
+        self.original_shape = None
+        
+    def prepare_for_display(self, image, max_width=1200, max_height=800):
+        """
+        Prepares image for display by padding, scaling, and rotating.
+        TRACKS all transformations for later reversal.
+        
+        Args:
+            image: 2D numpy array in NATIVE orientation
+            max_width: maximum display width
+            max_height: maximum display height
+            
+        Returns:
+            PIL.Image: transformed image ready for canvas display
+        """
+        from PIL import Image
+        
+        self.original_shape = image.shape  # Store native shape
+        
+        # Step 1: Pad the image
+        padded_image = np.pad(
+            image,
+            pad_width=((self.padding, self.padding), (self.padding, self.padding)),
+            mode="constant",
+            constant_values=0
+        )
+        self.padded_shape = padded_image.shape
+        
+        # Step 2: Normalize for display
+        padded_image = ImageProcessor.normalize_image(padded_image)
+        
+        # Step 3: Calculate scale to fit in display area
+        orig_height, orig_width = padded_image.shape
+        self.scale = min(max_width / orig_width, max_height / orig_height, 1)
+        
+        # Step 4: Resize
+        pil_height = int(padded_image.shape[0] * self.scale)
+        pil_width = int(padded_image.shape[1] * self.scale)
+        pil_image = Image.fromarray(padded_image).resize((pil_width, pil_height))
+        
+        # Step 5: Rotate 90 degrees for canvas display
+        pil_image = pil_image.rotate(90, expand=True)
+        
+        return pil_image
+    
+    def canvas_to_native_coords(self, canvas_points, rotated_width, rotated_height):
+        """
+        Converts polygon points from canvas coordinates back to NATIVE image coordinates.
+        
+        This is the INVERSE of all display transformations:
+        1. Undo rotation (90 degrees)
+        2. Undo scaling
+        3. Undo padding
+        
+        Args:
+            canvas_points: list of (x, y) tuples from canvas
+            rotated_width: width of rotated canvas
+            rotated_height: height of rotated canvas
+            
+        Returns:
+            list of (row, col) tuples in NATIVE image coordinates
+        """
+        native_points = []
+        
+        for x, y in canvas_points:
+            # Step 1: Undo rotation (90 degrees clockwise)
+            # After rotation: canvas(x, y) -> pre-rotation(rotated_height - y, x)
+            px = rotated_height - y
+            py = x
+            
+            # Step 2: Undo scaling
+            px = px / self.scale
+            py = py / self.scale
+            
+            # Step 3: Undo padding
+            px -= self.padding
+            py -= self.padding
+            
+            # Step 4: Clamp to valid image coordinates
+            px = int(np.clip(px, 0, self.original_shape[0] - 1))
+            py = int(np.clip(py, 0, self.original_shape[1] - 1))
+            
+            native_points.append((px, py))
+        
+        return native_points
+
+
+class MaskManager:
+    """Mask creation and saving operations with proper orientation handling."""
+    
+    @staticmethod
+    def create_mask(image, points):
+        """
+        Creates a binary mask from a polygon defined by points.
+        Points should be in the SAME coordinate system as the image.
+        
+        Args:
+            image (numpy.ndarray): Input image (2D)
+            points (list of tuples): Polygon coordinates as [(row1, col1), (row2, col2), ...]
+                                    in NATIVE image coordinates
+        
+        Returns:
+            tuple: (masked_image, binary_mask)
+        """
         if len(points) < 3:
             raise ValueError("At least 3 points are required to create a polygon mask.")
         
-        # Adjust the points to the original image scale
-        scale = 1 / reduction_scale
-        scaled_points = [(int(x * scale), int(y * scale)) for (x, y) in points]
-        
+        # Create mask in same orientation as image
         mask = np.zeros_like(image, dtype=np.uint8)
-        pts = np.array([scaled_points], dtype=np.int32)
+        pts = np.array([points], dtype=np.int32)
         mask = np.ascontiguousarray(mask)
         cv2.fillPoly(mask, pts, 255)
-
-        # Use only one channel for bitwise operations 
+        
+        # Apply mask to image
         result = cv2.bitwise_and(image, image, mask=mask)
         return result, mask
     
     @staticmethod
-    def create_combined_mask(image, polygons, reduction_scale=1.0):
+    def create_combined_mask(image, polygons):
         """
-        Creates a combined binary mask from multiple polygons and applies it to an image.
-
-        This method generates a unified mask by combining multiple polygon regions through
-        union operation. Each polygon contributes to the final mask, allowing multi-region
-        segmentation in a single operation.
-
+        Creates a combined binary mask from multiple polygons.
+        All polygons should be in NATIVE image coordinates.
+        
         Args:
-            image (numpy.ndarray): Input image to apply the combined mask to.
-            polygons (list of lists): List of polygons, where each polygon is a list of 
-                                     coordinate tuples: [[(x1,y1), (x2,y2), ...], ...].
-            reduction_scale (float, optional): Scale factor used to reduce the original image.
-                                             Points will be scaled up by 1/reduction_scale.
-                                             Defaults to 1.0 (no scaling).
-
+            image (numpy.ndarray): Input image (2D)
+            polygons (list of lists): List of polygons, each as [(row, col), ...]
+        
         Returns:
-            tuple: A tuple containing:
-                - masked_image (numpy.ndarray): Original image with combined mask applied.
-                - combined_mask (numpy.ndarray): Unified binary mask where all polygon areas 
-                                               are white (255) and background is black (0).
-
-        Note:
-            Polygons with fewer than 3 points are automatically skipped as they cannot form 
-            valid polygons. The method uses maximum operation to combine masks, ensuring 
-            overlapping regions are properly handled.
-
-        Example:
-            >> polygons = [
-            ..     [(100, 100), (150, 100), (125, 150)],  # Triangle
-            ..     [(200, 200), (250, 200), (225, 250)]   # Another triangle
-            .. ]
-            >> masked_img, combined_mask = MaskManager.create_combined_mask(
-            ..     image, polygons, reduction_scale=0.5
-            .. )
-            >> # Both regions will be visible in the combined mask
+            tuple: (masked_image, combined_mask)
         """
-
         combined_mask = np.zeros_like(image, dtype=np.uint8)
+        
         for poly in polygons:
             if len(poly) >= 3:
-                _, mask = MaskManager.create_mask(image, poly, reduction_scale=reduction_scale)
-                combined_mask = np.maximum(combined_mask, mask)  # union of all polygons
+                _, mask = MaskManager.create_mask(image, poly)
+                combined_mask = np.maximum(combined_mask, mask)  # Union
+        
         result = cv2.bitwise_and(image, image, mask=combined_mask)
         return result, combined_mask
     
     @staticmethod
     def measure_mask_area(mask):
-        ''' 
-            Return mask non zeros
-        '''
+        """Return number of non-zero pixels in mask."""
         return np.count_nonzero(mask)
     
-    @staticmethod 
-    
-    def create_final_mask(folder_path, original_shape, original_affine):
-        """
-        Creates a 3D NIfTI mask from PNG images with dimension matching.
-
-        Before stacking PNG slices, identifies the slice dimension in the original volume
-        and ensures proper orientation by comparing spatial dimensions.
-        """
-        mask_path = os.path.join(folder_path, 'mask.nii')
-
-        # Load and sort NPY files
-        npy_files = [f for f in os.listdir(folder_path) if f.endswith('.npy')]
-        if not npy_files:
-            raise FileNotFoundError(f"No NPY files found in {folder_path}")
-
-        images = []
-        for f in npy_files:
-            array = np.load(os.path.join(folder_path, f))
-            images.append(array)
-
-        print(f"Loaded {len(images)} PNG slices")
-        print(f"Original shape: {original_shape}")
-        print(f"PNG image shape: {images[0].shape}")
-
-        # Identify slice dimension in original volume (smallest dimension)
-        slice_dim = np.argmin(original_shape)
-        num_slices_original = original_shape[slice_dim]
-        num_slices_png = len(images)
-
-        assert num_slices_png == num_slices_original, "Something wrong happened: The number of .png files is diferent from the number of slices in original volume image."
-
-
-        # Get spatial dimensions from original volume (the two non-slice dimensions)
-        spatial_dims = [i for i in range(3) if i != slice_dim]
-        original_spatial_shape = (original_shape[spatial_dims[0]], original_shape[spatial_dims[1]])
-
-        print(f"Original spatial dimensions: {original_spatial_shape}")
-        print(f"Numpy spatial dimensions: {images[0].shape}")
-
-        # Stack with proper orientation
-        volume = MaskManager._stack_arrays_preserving_orientation(images, original_shape)
-
-        print(f"Final volume shape: {volume.shape}")
-        print(f"Target shape: {original_shape}")
-        
-        # Convert to binary (0 and 1)
-        volume_binary = (volume > 0).astype(np.uint8)
-
-        # --- FIX: correct flipped orientation (Z-axis flip) ---
-        volume_binary = np.flip(volume_binary, axis=2)
-        
-        # Save NIfTI
-        mask_nii = nib.Nifti1Image(volume_binary, original_affine)
-        nib.save(mask_nii, mask_path)        
-        print(f"Mask successfully saved to {mask_path}")
-
-        # removing numpy files after mask creation
-        removed_count=0
-        for npy_file in npy_files:
-            try:
-                file_path = os.path.join(folder_path, npy_file)
-                os.remove(file_path)
-                removed_count += 1
-                print(f"Removed: {npy_file}")
-            except Exception as e:
-                print(f"Error removing {npy_file}: {e}")
-
-        return mask_path
-        
-
     @staticmethod
-    def _stack_arrays_preserving_orientation(arrays, original_shape):
+    def save_mask(mask_2d, original_shape, affine, file_path, file_name="dense.nii"):
         """
-        Stacks 2D arrays into 3D volume while preserving original orientation.
-        Assumes arrays are in the same orientation as original slices.
-        """
-        # Identify slice dimension
-        slice_dim = np.argmin(original_shape)
-
-        # Stack along the slice dimension
-        if slice_dim == 0:
-            volume = np.stack(arrays, axis=0)
-        elif slice_dim == 1:
-            volume = np.stack(arrays, axis=1)
-        else:  # slice_dim == 2
-            volume = np.stack(arrays, axis=2)
-
-        # Verify dimensions match
-        if volume.shape != original_shape:
-            print(f"Warning: Stacked shape {volume.shape} doesn't match original {original_shape}")
-            # Apply minimal transformations to match
-            volume = MaskManager._match_volume_dimensions(volume, original_shape)
-
-        return volume
-
-    @staticmethod
-    def _match_volume_dimensions(volume, target_shape):
-        """
-        Applies minimal transformations to match target dimensions.
-        """
-        # Simple transpose if dimensions are swapped
-        if (volume.shape[0] == target_shape[1] and 
-            volume.shape[1] == target_shape[0] and 
-            volume.shape[2] == target_shape[2]):
-            return np.transpose(volume, (1, 0, 2))
-        elif (volume.shape[0] == target_shape[0] and 
-              volume.shape[1] == target_shape[2] and 
-              volume.shape[2] == target_shape[1]):
-            return np.transpose(volume, (0, 2, 1))
-
-        return volume  # Return as-is if no simple transformation works
-    
-    @staticmethod
-    def save_mask(mask, original_shape, nb_of_slices, affine, file_path, file_name="dense.nii"):
-        """
-        Saves a 2D mask as a 3D NIfTI file while preserving the original volume dimensions.
-
-        This method ensures the output mask has exactly the same dimensions as the original
-        medical image, which is essential for proper registration and analysis in medical
-        software. The mask is placed in the correct slice position within the 3D volume.
-
+        Saves a 2D mask as a 3D NIfTI file in NATIVE orientation.
+        
+        The key insight: The mask_2d is already in the NATIVE orientation of a slice.
+        We just need to replicate it across all slices in the correct dimension.
+        
         Args:
-            mask (numpy.ndarray): 2D binary mask to be saved (single slice).
-            original_shape (tuple): 3D shape of the original image (slices, height, width).
-            affine (numpy.ndarray): 4x4 affine transformation matrix for NIfTI header.
-            file_path (str): Directory path where the mask will be saved.
-            file_name (str, optional): Output filename. Defaults to "dense.nii".
-
+            mask_2d (numpy.ndarray): 2D binary mask in NATIVE slice orientation
+            original_shape (tuple): 3D shape of the original volume (e.g., (512, 512, 50))
+            affine (numpy.ndarray): 4x4 affine transformation matrix from original image
+            file_path (str): Directory path where mask will be saved
+            file_name (str): Output filename
+        
         Returns:
-            str: Full path to the saved mask file.
-
-        Raises:
-            ValueError: If original_shape is not 3D or incompatible with mask dimensions.
-
-        Example:
-            >>> # Original image shape: (50, 512, 512) - 50 slices of 512x512
-            >>> # Mask is for slice 25 (central slice)
-            >>> save_mask(mask_2d, (50, 512, 512), affine, "/output/path")
-            >>> # Result: 3D volume with mask only in slice 25, others are zeros
+            str: Full path to saved mask file
         """
         if len(original_shape) != 3:
             raise ValueError(f"original_shape must be 3D, got {len(original_shape)}D")
-
-        # Verify mask dimensions match the original image's slice dimensions
-        if nb_of_slices not in original_shape:
-            raise ValueError(f"Wrong number of slices: it was passed {nb_of_slices} to the function but original shape was {original_shape}")
-
+        
         os.makedirs(file_path, exist_ok=True)
-
-        # Ensure the mask is properly oriented for the original volume
-        # Apply the same transformations that were used when extracting the slice
-        oriented_mask = MaskManager._orient_mask_for_volume(mask, original_shape)
-
-        # Apply the same affine transformation as the original image
-        mask_nii = nib.Nifti1Image(oriented_mask, affine)
-
-        full_path = os.path.join(file_path, file_name)
-        nib.save(mask_nii, full_path)
-
-        print(f"Mask saved to {full_path} with original dimensions: {mask_nii.shape}")
-        return full_path
-
-    @staticmethod
-    def _orient_mask_for_volume(mask_2d, original_shape):
-        """
-        Creates a 3D volume from a 2D mask that matches the original volume's dimension order.
         
-        Args:
-            mask_2d (numpy.ndarray): 2D binary mask from canvas drawing
-            original_shape (tuple): 3D shape of original volume (dim1, dim2, dim3)
-            
-        Returns:
-            numpy.ndarray: 3D volume with mask replicated across slices, matching original_shape
-        """
-        # First, ensure the 2D mask matches the slice dimensions of the original volume
-        slice_dims = MaskManager._get_slice_dimensions(original_shape)
-        oriented_mask_2d = MaskManager._orient_2d_mask(mask_2d, slice_dims)
-        print(f"slices_dims:{slice_dims}")
-        
-        # Create 3D volume by replicating the mask across all slices
-        # Determine which dimension contains the slices
-        slice_dim = MaskManager._identify_slice_dimension(original_shape)
-        
-        # Create empty volume with original shape
-        mask_3d = np.zeros(original_shape, dtype=np.uint8)
-        print(original_shape)
-        
-        # Use np.repeat for better performance
-        if slice_dim == 0:  # Slices are first dimension (z, x, y)
-            # Repeat along the first axis (axis=0)
-            mask_3d = np.repeat(oriented_mask_2d[np.newaxis, :, :], original_shape[0], axis=0)
-
-        elif slice_dim == 1:  # Slices are second dimension (x, z, y)
-            # Repeat along the second axis (axis=1)
-            mask_3d = np.repeat(oriented_mask_2d[:, np.newaxis, :], original_shape[1], axis=1)
-
-        else:  # Slices are third dimension (x, y, z)
-            # Repeat along the third axis (axis=2)
-            mask_3d = np.repeat(oriented_mask_2d[:, :, np.newaxis], original_shape[2], axis=2)
-
-        return mask_3d
-
-    @staticmethod
-    def _get_slice_dimensions(original_shape):
-        """
-        Identifies which dimensions correspond to slice height and width.
-        Returns (height, width) of individual slices.
-        """
-        # Find the slice dimension (smallest dimension)
+        # Identify which dimension contains slices (usually smallest)
         slice_dim = np.argmin(original_shape)
         
-        # The other two dimensions are the slice height and width
+        # Build the expected 2D shape for a slice
         other_dims = [i for i in range(3) if i != slice_dim]
+        expected_slice_shape = (original_shape[other_dims[0]], original_shape[other_dims[1]])
         
-        # Return the dimensions in their original order
-        height_dim, width_dim = other_dims[0], other_dims[1]
+        # Verify mask dimensions match expected slice dimensions
+        # If they don't match, try transpose
+        if mask_2d.shape != expected_slice_shape:
+            if mask_2d.shape == expected_slice_shape[::-1]:
+                mask_2d = mask_2d.T
+            else:
+                # Last resort: resize (should generally not happen with proper coordinate transform)
+                print(f"WARNING: Mask shape {mask_2d.shape} doesn't match expected {expected_slice_shape}")
+                mask_2d = cv2.resize(mask_2d, expected_slice_shape[::-1], interpolation=cv2.INTER_NEAREST)
         
-        print(f"Slice dimension: {slice_dim} (size: {original_shape[slice_dim]})")
+        # Create 3D volume by replicating mask across all slices
+        mask_3d = np.zeros(original_shape, dtype=np.uint8)
         
-        return (original_shape[height_dim], original_shape[width_dim])
-
+        if slice_dim == 0:
+            # Slices along first dimension: shape = (n_slices, height, width)
+            for i in range(original_shape[0]):
+                mask_3d[i, :, :] = mask_2d
+        elif slice_dim == 1:
+            # Slices along second dimension: shape = (height, n_slices, width)
+            for i in range(original_shape[1]):
+                mask_3d[:, i, :] = mask_2d
+        else:  # slice_dim == 2
+            # Slices along third dimension: shape = (height, width, n_slices)
+            for i in range(original_shape[2]):
+                mask_3d[:, :, i] = mask_2d
+        
+        # Save with original affine - this preserves spatial registration
+        mask_nii = nib.Nifti1Image(mask_3d, affine)
+        full_path = os.path.join(file_path, file_name)
+        nib.save(mask_nii, full_path)
+        
+        print(f"Mask saved to {full_path}")
+        print(f"  Shape: {mask_3d.shape} (matches original: {original_shape})")
+        print(f"  Slice dimension: {slice_dim}")
+        
+        return full_path
+    
     @staticmethod
-    def _identify_slice_dimension(original_shape):
+    def create_final_mask(folder_path, original_shape, original_affine):
         """
-        Identifies which dimension corresponds to the slice direction (usually the smallest dimension).
+        Creates a 3D NIfTI mask from processed slice arrays.
+        
+        Args:
+            folder_path: directory containing .npy slice files
+            original_shape: 3D shape of original volume
+            original_affine: affine matrix from original volume
+            
+        Returns:
+            str: path to saved mask.nii file
         """
-        return np.argmin(original_shape)
+        mask_path = os.path.join(folder_path, 'mask.nii')
+        
+        # Load all .npy files
+        npy_files = sorted([f for f in os.listdir(folder_path) if f.endswith('.npy')])
+        if not npy_files:
+            raise FileNotFoundError(f"No NPY files found in {folder_path}")
+        
+        print(f"Loading {len(npy_files)} slice arrays...")
+        slices = []
+        for f in npy_files:
+            array = np.load(os.path.join(folder_path, f))
+            # Convert to binary (0 or 1)
+            binary_slice = (array > 0).astype(np.uint8)
+            slices.append(binary_slice)
+        
+        # Identify slice dimension
+        slice_dim = np.argmin(original_shape)
+        num_slices_expected = original_shape[slice_dim]
+        
+        if len(slices) != num_slices_expected:
+            raise ValueError(
+                f"Number of slice files ({len(slices)}) doesn't match "
+                f"expected slices ({num_slices_expected}) for dimension {slice_dim}"
+            )
+        
+        # Stack slices into 3D volume based on slice dimension
+        other_dims = [i for i in range(3) if i != slice_dim]
+        expected_slice_shape = (original_shape[other_dims[0]], original_shape[other_dims[1]])
+        
+        print(f"Expected slice shape: {expected_slice_shape}")
+        print(f"Actual slice shape: {slices[0].shape}")
+        
+        # Verify and potentially transpose slices
+        for i in range(len(slices)):
+            if slices[i].shape != expected_slice_shape:
+                if slices[i].shape == expected_slice_shape[::-1]:
+                    slices[i] = slices[i].T
+                else:
+                    raise ValueError(
+                        f"Slice {i} shape {slices[i].shape} doesn't match expected {expected_slice_shape}"
+                    )
+        
+        # Stack along the correct dimension
+        if slice_dim == 0:
+            volume = np.stack(slices, axis=0)
+        elif slice_dim == 1:
+            volume = np.stack(slices, axis=1)
+        else:  # slice_dim == 2
+            volume = np.stack(slices, axis=2)
+        
+        print(f"Final volume shape: {volume.shape}")
+        print(f"Expected shape: {original_shape}")
+        
+        if volume.shape != original_shape:
+            raise ValueError(
+                f"Final volume shape {volume.shape} doesn't match original {original_shape}"
+            )
+        
+        # Save NIfTI with original affine
+        mask_nii = nib.Nifti1Image(volume, original_affine)
+        nib.save(mask_nii, mask_path)
+        
+        print(f"Final mask saved to {mask_path}")
+        return mask_path
 
-    @staticmethod
-    def _orient_2d_mask(mask_2d, target_slice_dims):
-        """
-        Orients the 2D mask to match the target slice dimensions (height, width).
-        """
-        target_height, target_width = target_slice_dims
-
-        # If dimensions already match, return as-is
-        if mask_2d.shape == (target_height, target_width):
-            return mask_2d
-
-        # If dimensions are swapped, transpose
-        if mask_2d.shape == (target_width, target_height):
-            return mask_2d.T
-
-        # If still no match, resize to fit
-        return cv2.resize(mask_2d.astype(np.float32), (target_width, target_height)).astype(np.uint8)
 
 class ThresholdOperator:
+    """Threshold operations for segmentation."""
+    
     @staticmethod
     def apply_threshold(image, mask, threshold):
+        """Apply threshold to normalized image within mask region."""
         norm_image = ImageProcessor.normalize_data(image)
         return (norm_image > threshold) & (mask > 0)
-
+    
     @staticmethod
     def threshold_slice(img, mask, threshold):
-        bin_mask = ThresholdOperator.apply_threshold(img, mask, threshold)
-        return bin_mask
+        """Apply threshold to a slice."""
+        return ThresholdOperator.apply_threshold(img, mask, threshold)
     
     @staticmethod
     def display_thresholded_slice(img, mask, threshold):
+        """
+        Display thresholded result overlaid on image.
+        
+        Args:
+            img: normalized image for display
+            mask: binary mask
+            threshold: threshold value
+            
+        Returns:
+            matplotlib figure
+        """
         bin_mask = ThresholdOperator.threshold_slice(img, mask, threshold)
         fig, ax = plt.subplots(figsize=(8, 8))
         ax.imshow(img, cmap='gray')
@@ -404,20 +377,36 @@ class ThresholdOperator:
     
     @staticmethod
     def adjust_slice_threshold(image_slice, mask_slice, target_area):
+        """
+        Automatically adjusts threshold to match target area.
+        
+        Args:
+            image_slice: image slice to threshold
+            mask_slice: mask defining region of interest
+            target_area: target number of pixels
+            
+        Returns:
+            tuple: (best_threshold, thresholded_image)
+        """
         threshold = 0.8
         step = 0.01
         best_threshold = threshold
         best_diff = float('inf')
-
+        
         while threshold >= 0:
-            thresholded_image = ThresholdOperator.threshold_slice(image_slice, mask_slice, threshold)
+            thresholded_image = ThresholdOperator.threshold_slice(
+                image_slice, mask_slice, threshold
+            )
             area = MaskManager.measure_mask_area(thresholded_image)
             diff = abs(area - target_area)
-
+            
             if diff < best_diff:
                 best_diff = diff
                 best_threshold = threshold
-
+            
             threshold -= step
-
-        return best_threshold, ThresholdOperator.threshold_slice(image_slice, mask_slice, best_threshold)
+        
+        final_thresholded = ThresholdOperator.threshold_slice(
+            image_slice, mask_slice, best_threshold
+        )
+        return best_threshold, final_thresholded


### PR DESCRIPTION
Fix critical issues with mask orientation/spatial registration and make outputs follow the input format (NIfTI -> NIfTI, DICOM -> DICOM), ensuring dense/mask products remain consistent with the source dataset.

Major changes:

Keep all computations/saving in native orientation (no dimension rearrangement) and use DisplayTransform only for GUI display + coordinate inversion

Update drawing step to convert canvas polygons -> native pixel coordinates before rasterizing masks

Add format-aware output resolution: if input is DICOM, export dense/mask as DICOM (single-file or series); if input is NIfTI, export as NIfTI preserving affine/shape

Introduce robust output discovery helpers (resolve_dense_mask_path, resolve_final_mask_path) to support both NIfTI and DICOM artifacts in the pipeline

Update processing step to load/save using the same format as the original input while preserving slice ordering and spatial metadata

BREAKING CHANGE: The pipeline now produces dense/mask artifacts in the same format as the input and loads images in native orientation; existing outputs (and any masks produced by the old mixed-format flow) may need to be regenerated